### PR TITLE
task(AMD-9): Create Methods to create jwt for users

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/jsonwebtoken": "^8.5.6",
         "apollo-server-express": "^3.5.0",
         "argon2": "^0.28.2",
         "axios": "^0.24.0",
@@ -441,6 +442,14 @@
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.1.tgz",
       "integrity": "sha512-raYHPqRWrfnEoym94BY28mG1+tcZqh3dsp2q7x5IyMAAEvIdu+H0X8diASMpncIm+oHyH9dalOeOnGOL/YnuOA==",
       "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.6.tgz",
+      "integrity": "sha512-+P3O/xC7nzVizIi5VbF34YtqSonFsdnbXBnWUCYRiKOi1f9gA4sEFvXkrGr/QVV23IbMYvcoerI7nnhDUiWXRQ==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4668,6 +4677,14 @@
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.1.tgz",
       "integrity": "sha512-raYHPqRWrfnEoym94BY28mG1+tcZqh3dsp2q7x5IyMAAEvIdu+H0X8diASMpncIm+oHyH9dalOeOnGOL/YnuOA==",
       "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/jsonwebtoken": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.6.tgz",
+      "integrity": "sha512-+P3O/xC7nzVizIi5VbF34YtqSonFsdnbXBnWUCYRiKOi1f9gA4sEFvXkrGr/QVV23IbMYvcoerI7nnhDUiWXRQ==",
       "requires": {
         "@types/node": "*"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/jsonwebtoken": "^8.5.6",
     "apollo-server-express": "^3.5.0",
     "argon2": "^0.28.2",
     "axios": "^0.24.0",

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -1,18 +1,19 @@
-import dotenv from "dotenv";
+import dotenv from "dotenv"
 
-dotenv.config();
+dotenv.config()
 
-export const __prod__ = process.env.NODE_ENV === "production";
-export const __postgres__ = {
-  MYSQL_USER: process.env.MYSQL_USER,
-  MYSQL_PASSWORD: process.env.MYSQL_PASSWORD,
-  MYSQL_DB: process.env.MYSQL_DB,
-};
+export const __prod__ = process.env.NODE_ENV === "production"
+
+export const __jwt__ = {
+  secret: process.env.JWT_SECRET as string,
+}
+
 export const __redis__ = {
   REDIS_URL: process.env.REDIS_URL,
-};
+}
+
 export const __mysql__ = {
   MYSQL_USER: process.env.MYSQL_USER,
   MYSQL_PASSWORD: process.env.MYSQL_PASSWORD,
   MYSQL_DB: process.env.MYSQL_DB,
-};
+}

--- a/server/src/utils/jwtHandler.ts
+++ b/server/src/utils/jwtHandler.ts
@@ -1,1 +1,25 @@
-export class HandleJWT {}
+import * as jwt from "jsonwebtoken"
+import { __jwt__ } from "../constants"
+
+type PayloadType = string | object | Buffer
+type CreateJWTOptionsType = Omit<jwt.SignOptions, "algorithm">
+type CreateIdOptionsType = Omit<CreateJWTOptionsType, "jwtId">
+export class HandleJWT {
+  private secret: string
+  constructor() {
+    this.secret = __jwt__.secret
+  }
+
+  private createJWT(payload: PayloadType, options: CreateJWTOptionsType) {
+    const token = jwt.sign(payload, this.secret, {
+      ...options,
+      algorithm: "HS512",
+      expiresIn: options.expiresIn || "24h",
+    })
+    return token
+  }
+
+  public createIdJWT(payload: PayloadType, options: CreateIdOptionsType) {
+    return this.createJWT(payload, { ...options, jwtid: "AMD-ID" })
+  }
+}


### PR DESCRIPTION
Created two methods:
- createIdJWT - used to create a JWT with the jwtId `AMD-ID`. createIdJWT is used for identification purposes only
- createJWT - used privately inside createIdJWT. created so other versions of createIdJWT can be made for other purposes.